### PR TITLE
refactor: 동아리 회원 삭제 시, 비회원이면서 동아리 소속이 없는 경우 프로필 삭제

### DIFF
--- a/src/main/java/com/USWCicrcleLink/server/club/club/repository/ClubMembersRepositoryCustom.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/club/repository/ClubMembersRepositoryCustom.java
@@ -10,4 +10,5 @@ public interface ClubMembersRepositoryCustom {
     List<ClubMembers> findAllWithProfileByClubClubId(Long clubId);
     List<ClubMembers> findAllWithProfileByName(Long clubId);
     List<ClubMembers> findAllWithProfileByMemberType(Long clubId, MemberType memberType);
+    List<Long> findByProfileProfileIdsWithoutClub(List<Long> profileIds);
 }

--- a/src/main/java/com/USWCicrcleLink/server/club/club/repository/ClubMembersRepositoryImpl.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/club/repository/ClubMembersRepositoryImpl.java
@@ -51,4 +51,16 @@ public class ClubMembersRepositoryImpl implements ClubMembersRepositoryCustom {
                 .getResultList();
     }
 
+    // 프로필로 속한 동아리 조회
+    @Override
+    public List<Long> findByProfileProfileIdsWithoutClub(List<Long> profileIds) {
+        return em.createQuery(
+                        "SELECT p.profileId FROM Profile p" +
+                                " WHERE p.profileId IN :profileIds" +
+                                " AND NOT EXISTS (SELECT 1 FROM ClubMembers cm WHERE cm.profile.profileId = p.profileId)",
+                        Long.class
+                ).setParameter("profileIds", profileIds)
+                .getResultList();
+
+    }
 }


### PR DESCRIPTION
동아리 회원 삭제
- 비회원이면서 동아리 소속이 없는 경우 프로필도 삭제