### PR TITLE
동아리 정보 부분 수정 / /clubs role 별 구분

### DIFF
--- a/src/main/java/com/USWCicrcleLink/server/club/api/ClubController.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/api/ClubController.java
@@ -13,7 +13,6 @@ import com.USWCicrcleLink.server.club.leader.dto.FcmTokenRequest;
 import com.USWCicrcleLink.server.club.leader.dto.club.ClubInfoRequest;
 import com.USWCicrcleLink.server.club.leader.dto.club.ClubProfileRequest;
 import com.USWCicrcleLink.server.club.leader.dto.club.ClubProfileResponse;
-import com.USWCicrcleLink.server.club.leader.dto.club.LeaderClubInfoResponse;
 import com.USWCicrcleLink.server.club.leader.dto.clubMembers.ClubMembersResponse;
 import com.USWCicrcleLink.server.club.leader.dto.clubMembers.ClubMembersDeleteRequest;
 import com.USWCicrcleLink.server.club.leader.service.ClubLeaderService;
@@ -118,16 +117,19 @@ public class ClubController {
         return ResponseEntity.ok(clubProfile);
     }
 
-    // 동아리 관리 정보 수정 (Leader) -> updateClubProfile (was updateClubInfo)
+    // 동아리 정보 수정 (Leader)
     @PutMapping("/{clubUUID}")
-    public ResponseEntity<ApiResponse> updateClubProfile(
+    public ResponseEntity<ApiResponse> updateClub(
             @PathVariable("clubUUID") UUID clubUUID,
             @RequestPart(value = "mainPhoto", required = false) MultipartFile mainPhoto,
             @RequestPart(value = "clubProfileRequest", required = false) @Validated(ValidationSequence.class) ClubProfileRequest clubProfileRequest,
             @RequestPart(value = "leaderUpdatePwRequest", required = false) @Validated(ValidationSequence.class) com.USWCicrcleLink.server.club.leader.dto.LeaderUpdatePwRequest leaderUpdatePwRequest,
+            @RequestPart(value = "clubInfoRequest", required = false) @jakarta.validation.Valid ClubInfoRequest clubInfoRequest,
+            @RequestPart(value = "infoPhotos", required = false) List<MultipartFile> infoPhotos,
             HttpServletResponse response) throws IOException {
 
-        ApiResponse result = clubLeaderService.updateClubProfile(clubUUID, clubProfileRequest, mainPhoto);
+        ApiResponse result = clubLeaderService.updateClub(clubUUID, clubProfileRequest, mainPhoto, clubInfoRequest,
+                infoPhotos);
         if (leaderUpdatePwRequest != null) {
             clubLeaderService.updatePassword(leaderUpdatePwRequest, response);
         }
@@ -193,42 +195,31 @@ public class ClubController {
 
     // --- Added from ClubLeaderController ---
 
-    // 동아리 요약 조회
-    @GetMapping("/{clubUUID}/summary")
-    public ResponseEntity<ApiResponse<com.USWCicrcleLink.server.club.leader.dto.club.ClubSummaryResponse>> getClubSummary(
-            @PathVariable("clubUUID") UUID clubUUID) {
-        com.USWCicrcleLink.server.club.leader.dto.club.ClubSummaryResponse clubSummaryResponse = clubLeaderService
-                .getClubSummary(clubUUID);
-        ApiResponse<com.USWCicrcleLink.server.club.leader.dto.club.ClubSummaryResponse> response = new ApiResponse<>(
-                "동아리 요약 조회 완료", clubSummaryResponse);
-        return ResponseEntity.ok(response);
-    }
-
-    // 동아리 소개 조회 (Leader) -> getClubInfo (was getClubIntro)
-    @GetMapping("/{clubUUID}/info")
-    public ResponseEntity<ApiResponse<LeaderClubInfoResponse>> getClubInfo(
-            @PathVariable("clubUUID") UUID clubUUID) {
-        return new ResponseEntity<>(clubLeaderService.getClubInfo(clubUUID), HttpStatus.OK);
-    }
-
-    // 동아리 소개 변경 -> updateClubInfo (was updateClubIntro)
-    @PutMapping("/{clubUUID}/info")
-    public ResponseEntity<ApiResponse> updateClubInfo(@PathVariable("clubUUID") UUID clubUUID,
-            @RequestPart(value = "clubInfoRequest", required = false) @jakarta.validation.Valid ClubInfoRequest clubInfoRequest,
-            @RequestPart(value = "infoPhotos", required = false) List<MultipartFile> infoPhotos) throws IOException {
-
-        return new ResponseEntity<>(clubLeaderService.updateClubInfo(clubUUID, clubInfoRequest, infoPhotos),
-                HttpStatus.OK);
-    }
+    // // 동아리 요약 조회
+    // @GetMapping("/{clubUUID}/summary")
+    // public
+    // ResponseEntity<ApiResponse<com.USWCicrcleLink.server.club.leader.dto.club.ClubSummaryResponse>>
+    // getClubSummary(
+    // @PathVariable("clubUUID") UUID clubUUID) {
+    // com.USWCicrcleLink.server.club.leader.dto.club.ClubSummaryResponse
+    // clubSummaryResponse = clubLeaderService
+    // .getClubSummary(clubUUID);
+    // ApiResponse<com.USWCicrcleLink.server.club.leader.dto.club.ClubSummaryResponse>
+    // response = new ApiResponse<>(
+    // "동아리 요약 조회 완료", clubSummaryResponse);
+    // return ResponseEntity.ok(response);
+    // }
 
     // 지원서 상세 조회
-    @GetMapping("/{clubUUID}/applications/{applicationUUID}")
-    public ResponseEntity<ApiResponse<com.USWCicrcleLink.server.club.application.dto.AplictDto.DetailResponse>> getApplicationDetail(
-            @PathVariable("clubUUID") UUID clubUUID,
-            @PathVariable("applicationUUID") UUID applicationUUID) {
-        return ResponseEntity.ok(new ApiResponse<>("지원서 상세 조회 완료",
-                clubLeaderService.getApplicationDetail(clubUUID, applicationUUID)));
-    }
+    // @GetMapping("/{clubUUID}/applications/{applicationUUID}")
+    // public
+    // ResponseEntity<ApiResponse<com.USWCicrcleLink.server.club.application.dto.AplictDto.DetailResponse>>
+    // getApplicationDetail(
+    // @PathVariable("clubUUID") UUID clubUUID,
+    // @PathVariable("applicationUUID") UUID applicationUUID) {
+    // return ResponseEntity.ok(new ApiResponse<>("지원서 상세 조회 완료",
+    // clubLeaderService.getApplicationDetail(clubUUID, applicationUUID)));
+    // }
 
     // 지원자 상태 변경
     @PatchMapping("/{clubUUID}/applications/{applicationUUID}/status")

--- a/src/main/java/com/USWCicrcleLink/server/club/clubInfo/domain/ClubInfo.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/clubInfo/domain/ClubInfo.java
@@ -38,10 +38,20 @@ public class ClubInfo {
     @Column(name = "club_info_recruitment_status", nullable = false)
     private RecruitmentStatus recruitmentStatus = RecruitmentStatus.CLOSE;
 
-    public void updateClubInfo(String clubInfo, String clubRecruitment, String googleFormUrl) {
-        this.clubInfo = clubInfo;
-        this.clubRecruitment = clubRecruitment;
-        this.googleFormUrl = googleFormUrl;
+    public void updateClubInfo(String clubInfo, String clubRecruitment, String googleFormUrl,
+            RecruitmentStatus recruitmentStatus) {
+        if (clubInfo != null) {
+            this.clubInfo = clubInfo;
+        }
+        if (clubRecruitment != null) {
+            this.clubRecruitment = clubRecruitment;
+        }
+        if (googleFormUrl != null) {
+            this.googleFormUrl = googleFormUrl;
+        }
+        if (recruitmentStatus != null) {
+            this.recruitmentStatus = recruitmentStatus;
+        }
     }
 
     public void toggleRecruitmentStatus() {

--- a/src/main/java/com/USWCicrcleLink/server/club/domain/Club.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/domain/Club.java
@@ -55,9 +55,17 @@ public class Club {
     }
 
     public void updateClubInfo(String leaderName, String leaderHp, String clubInsta, String clubRoomNumber) {
-        this.leaderName = leaderName;
-        this.leaderHp = leaderHp;
-        this.clubInsta = clubInsta;
-        this.clubRoomNumber = clubRoomNumber;
+        if (leaderName != null && !leaderName.isBlank()) {
+            this.leaderName = leaderName;
+        }
+        if (leaderHp != null && !leaderHp.isBlank()) {
+            this.leaderHp = leaderHp;
+        }
+        if (clubInsta != null) {
+            this.clubInsta = clubInsta;
+        }
+        if (clubRoomNumber != null && !clubRoomNumber.isBlank()) {
+            this.clubRoomNumber = clubRoomNumber;
+        }
     }
 }

--- a/src/main/java/com/USWCicrcleLink/server/club/dto/ClubListResponse.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/dto/ClubListResponse.java
@@ -17,6 +17,7 @@ public class ClubListResponse {
     private String department;
     private List<String> hashtags;
     private String leaderName;
+    private String leaderHp;
     private Long memberCount;
     private String recruitmentStatus;
 }

--- a/src/main/java/com/USWCicrcleLink/server/club/dto/ClubSearchCondition.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/dto/ClubSearchCondition.java
@@ -16,5 +16,9 @@ public class ClubSearchCondition {
     private Boolean open;
     private String filter;
     private List<UUID> categoryUUIDs;
-    private Boolean includeNumberOfMembers;
+    private Boolean includeAdminInfo;
+
+    public void setInclude_admin_info(Boolean includeAdminInfo) {
+        this.includeAdminInfo = includeAdminInfo;
+    }
 }

--- a/src/main/java/com/USWCicrcleLink/server/club/leader/dto/LeaderUpdatePwRequest.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/leader/dto/LeaderUpdatePwRequest.java
@@ -4,6 +4,8 @@ import com.USWCicrcleLink.server.global.validation.ValidationGroups;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
@@ -11,20 +13,16 @@ import lombok.AllArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LeaderUpdatePwRequest {
 	@NotBlank(message = "현재 비밀번호는 필수 입력 값입니다.", groups = ValidationGroups.NotBlankGroup.class)
 	private String leaderPw;
 
 	@NotBlank(message = "새 비밀번호는 필수 입력 값입니다.", groups = ValidationGroups.NotBlankGroup.class)
 	@Size(min = 8, max = 20, message = "비밀번호는 8~20자 이내여야 합니다.", groups = ValidationGroups.SizeGroup.class)
-	@Pattern(
-			regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?])(?!.*\\s).*$",
-			message = "비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 하며 공백을 포함할 수 없습니다.",
-			groups = ValidationGroups.PatternGroup.class
-	)
+	@Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?])(?!.*\\s).*$", message = "비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 하며 공백을 포함할 수 없습니다.", groups = ValidationGroups.PatternGroup.class)
 	private String newPw;
 
 	@NotBlank(message = "새 비밀번호 확인은 필수 입력 값입니다.", groups = ValidationGroups.NotBlankGroup.class)
 	private String confirmNewPw;
 }
-

--- a/src/main/java/com/USWCicrcleLink/server/club/leader/dto/club/ClubInfoRequest.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/leader/dto/club/ClubInfoRequest.java
@@ -4,17 +4,19 @@ import com.USWCicrcleLink.server.club.domain.RecruitmentStatus;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ClubInfoRequest {
 
     @Size(max = 3000, message = "소개글은 최대 3000자까지 입력 가능합니다.")
     private String clubInfo;
 
-    @NotNull(message = "모집 상태를 설정해주세요.")
     private RecruitmentStatus recruitmentStatus;
 
     @Size(max = 3000, message = "모집글은 최대 3000자까지 입력 가능합니다.")

--- a/src/main/java/com/USWCicrcleLink/server/club/leader/dto/club/ClubProfileRequest.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/leader/dto/club/ClubProfileRequest.java
@@ -2,6 +2,8 @@ package com.USWCicrcleLink.server.club.leader.dto.club;
 
 import com.USWCicrcleLink.server.global.validation.ValidClubRoomNumber;
 import com.USWCicrcleLink.server.global.validation.ValidationGroups;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -14,14 +16,13 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ClubProfileRequest {
 
-    @NotBlank(message = "회장 이름은 필수 입력 값입니다.", groups = ValidationGroups.NotBlankGroup.class)
     @Size(min = 2, max = 30, message = "회장 이름은 2~30자 이내여야 합니다.", groups = ValidationGroups.SizeGroup.class)
     @Pattern(regexp = "^[a-zA-Z가-힣]+$", message = "회장 이름은 영어 또는 한글만 입력 가능합니다.", groups = ValidationGroups.PatternGroup.class)
     private String leaderName;
 
-    @NotBlank(message = "전화번호는 필수 입력 값입니다.", groups = ValidationGroups.NotBlankGroup.class)
     @Size(min = 11, max = 11, message = "전화번호는 11자여야 합니다.", groups = ValidationGroups.SizeGroup.class)
     @Pattern(regexp = "^01[0-9]{9}$", message = "올바른 전화번호를 입력하세요.", groups = ValidationGroups.PatternGroup.class)
     private String leaderHp;
@@ -29,7 +30,6 @@ public class ClubProfileRequest {
     @Pattern(regexp = "^(https?://)?(www\\.)?instagram\\.com/.+$|^$", message = "유효한 인스타그램 링크를 입력해주세요.")
     private String clubInsta;
 
-    @NotBlank(message = "동아리방 호수는 필수 입력 값입니다.")
     @ValidClubRoomNumber(groups = ValidationGroups.PatternGroup.class)
     private String clubRoomNumber;
 

--- a/src/main/java/com/USWCicrcleLink/server/club/leader/repository/LeaderRepository.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/leader/repository/LeaderRepository.java
@@ -21,5 +21,7 @@ public interface LeaderRepository extends JpaRepository<Leader, Long> {
     Optional<UUID> findClubuuidByLeaderUUID(@Param("leaderUUID") UUID leaderUUID);
 
     @Query("SELECT l FROM Leader l WHERE l.club.clubuuid = :clubuuid")
-    Optional<Leader> findByClubuuid(@Param("clubuuid") UUID clubuuid);
+    Optional<Leader> findByClubuuid(@Param("clubuuid") java.util.UUID clubuuid);
+
+    java.util.List<Leader> findAllByClubClubIdIn(java.util.List<Long> clubIds);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Club leaders can now upload multiple gallery photos and update recruitment information in a single profile update
  * Administrators can view leader contact information in club search results

* **Improvements**
  * Relaxed input validation on certain club profile fields to support optional updates
  * Enhanced API consistency for request handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->