### PR TITLE
지원서 status 분기, 지원서 누적 

### DIFF
--- a/src/main/java/com/USWCicrcleLink/server/club/api/ClubController.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/api/ClubController.java
@@ -178,8 +178,10 @@ public class ClubController {
     @GetMapping("/{clubUUID}/applicants")
     public ResponseEntity<ApiResponse> getApplicants(
             @PathVariable("clubUUID") UUID clubUUID,
-            @RequestParam(value = "status", required = false) com.USWCicrcleLink.server.club.application.domain.AplictStatus status) {
-        return new ResponseEntity<>(clubLeaderService.getApplicants(clubUUID, status), HttpStatus.OK);
+            @RequestParam(value = "status", required = false) com.USWCicrcleLink.server.club.application.domain.AplictStatus status,
+            @RequestParam(value = "isResultPublished", required = false) Boolean isResultPublished) {
+        return new ResponseEntity<>(clubLeaderService.getApplicants(clubUUID, status, isResultPublished),
+                HttpStatus.OK);
     }
 
     // 합격자 알림

--- a/src/main/java/com/USWCicrcleLink/server/club/application/api/AplictController.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/application/api/AplictController.java
@@ -62,4 +62,13 @@ public class AplictController {
 
         return ResponseEntity.ok(new ApiResponse<>("지원서 상세 조회 성공", response));
     }
+
+    // 지원자 수동 삭제 (Leader)
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Void>> deleteApplicants(
+            @PathVariable("clubUUID") UUID clubUUID,
+            @RequestBody java.util.List<UUID> aplictUUIDs) {
+        clubLeaderService.deleteApplicants(clubUUID, aplictUUIDs);
+        return ResponseEntity.ok(new ApiResponse<>("지원자 삭제 성공"));
+    }
 }

--- a/src/main/java/com/USWCicrcleLink/server/club/application/domain/Aplict.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/application/domain/Aplict.java
@@ -39,10 +39,13 @@ public class Aplict {
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
-    @Column(name = "aplict_status", nullable = false, length = 10)
-    private AplictStatus aplictStatus = AplictStatus.WAIT;
+    @Column(name = "public_status", nullable = false, length = 10)
+    private AplictStatus publicStatus = AplictStatus.WAIT;
 
-    // checked field removed
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "private_status", nullable = false, length = 10)
+    private AplictStatus privateStatus = AplictStatus.WAIT;
 
     @Column(name = "aplict_delete_date")
     private LocalDateTime deleteDate;
@@ -54,13 +57,14 @@ public class Aplict {
         }
     }
 
-    public void updateAplictStatus(AplictStatus newStatus, LocalDateTime deleteDate) {
-        this.aplictStatus = newStatus;
-        this.deleteDate = deleteDate;
+    // 리더가 상태 변경 시 privateStatus만 변경
+    public void updatePrivateStatus(AplictStatus newStatus) {
+        this.privateStatus = newStatus;
     }
 
-    public void updateFailedAplictStatus(AplictStatus newStatus) {
-        this.aplictStatus = newStatus;
+    // 최종 결과 처리 시 publicStatus를 privateStatus와 동기화
+    public void publishResults() {
+        this.publicStatus = this.privateStatus;
     }
 
     @Builder.Default

--- a/src/main/java/com/USWCicrcleLink/server/club/application/dto/ApplicantResultsRequest.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/application/dto/ApplicantResultsRequest.java
@@ -8,6 +8,8 @@ import lombok.*;
 import java.util.UUID;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ApplicantResultsRequest {
 
     @NotNull(message = "지원서는 필수 입력값입니다.", groups = ValidationGroups.NotBlankGroup.class)

--- a/src/main/java/com/USWCicrcleLink/server/club/application/dto/ApplicantsResponse.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/application/dto/ApplicantsResponse.java
@@ -1,5 +1,6 @@
 package com.USWCicrcleLink.server.club.application.dto;
 
+import com.USWCicrcleLink.server.club.application.domain.AplictStatus;
 import com.USWCicrcleLink.server.user.profile.domain.Profile;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -22,13 +23,14 @@ public class ApplicantsResponse {
 
     private String userHp;
 
-    public ApplicantsResponse(UUID aplictUUID, Profile profile) {
+    private AplictStatus privateStatus;
+
+    public ApplicantsResponse(UUID aplictUUID, Profile profile, AplictStatus privateStatus) {
         this.aplictUUID = aplictUUID;
         this.userName = profile.getUserName();
         this.major = profile.getMajor();
         this.studentNumber = profile.getStudentNumber();
         this.userHp = profile.getUserHp();
+        this.privateStatus = privateStatus;
     }
 }
-
-

--- a/src/main/java/com/USWCicrcleLink/server/club/application/repository/AplictRepository.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/application/repository/AplictRepository.java
@@ -20,9 +20,9 @@ public interface AplictRepository extends JpaRepository<Aplict, Long>, AplictRep
 
         Optional<Aplict> findByClub_ClubIdAndAplictUUID(Long clubId, UUID aplictUUID); // Restored
 
-        List<Aplict> findByClub_ClubIdAndAplictStatus(Long clubId, AplictStatus status); // Restored
+        List<Aplict> findByClub_ClubIdAndPrivateStatus(Long clubId, AplictStatus status); // Restored
 
-        Optional<Aplict> findByClub_ClubIdAndAplictUUIDAndAplictStatus(Long clubId, UUID aplictUUID,
+        Optional<Aplict> findByClub_ClubIdAndAplictUUIDAndPrivateStatus(Long clubId, UUID aplictUUID,
                         AplictStatus status); // Restored
 
         List<Aplict> findAllWithProfileByClubIdAndStatus(Long clubId, AplictStatus status);

--- a/src/main/java/com/USWCicrcleLink/server/club/application/repository/AplictRepositoryCustom.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/application/repository/AplictRepositoryCustom.java
@@ -8,5 +8,7 @@ import java.util.List;
 public interface AplictRepositoryCustom {
     List<Aplict> findAllWithProfileByClubIdAndStatus(Long clubId, AplictStatus status);
 
+    List<Aplict> findApplicants(Long clubId, AplictStatus privateStatus, Boolean isResultPublished);
+
     List<Aplict> findAllWithProfileByClubId(Long clubId);
 }

--- a/src/main/java/com/USWCicrcleLink/server/club/application/repository/AplictRepositoryCustomImpl.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/application/repository/AplictRepositoryCustomImpl.java
@@ -19,10 +19,39 @@ public class AplictRepositoryCustomImpl implements AplictRepositoryCustom {
         public List<Aplict> findAllWithProfileByClubIdAndStatus(Long clubId, AplictStatus status) {
                 return em.createQuery(
                                 "SELECT ap FROM Aplict ap JOIN FETCH ap.profile p" +
-                                                " WHERE ap.club.id = :clubId AND ap.aplictStatus = :status",
+                                                " WHERE ap.club.id = :clubId AND ap.privateStatus = :status",
                                 Aplict.class).setParameter("clubId", clubId)
                                 .setParameter("status", status)
                                 .getResultList();
+        }
+
+        @Override
+        public List<Aplict> findApplicants(Long clubId, AplictStatus privateStatus, Boolean isResultPublished) {
+                String jpql = "SELECT ap FROM Aplict ap JOIN FETCH ap.profile p WHERE ap.club.id = :clubId";
+
+                if (privateStatus != null) {
+                        jpql += " AND ap.privateStatus = :privateStatus";
+                }
+
+                if (isResultPublished != null) {
+                        if (isResultPublished) {
+                                jpql += " AND ap.publicStatus <> :waitStatus";
+                        } else {
+                                jpql += " AND ap.publicStatus = :waitStatus";
+                        }
+                }
+
+                var query = em.createQuery(jpql, Aplict.class).setParameter("clubId", clubId);
+
+                if (privateStatus != null) {
+                        query.setParameter("privateStatus", privateStatus);
+                }
+
+                if (isResultPublished != null) {
+                        query.setParameter("waitStatus", AplictStatus.WAIT);
+                }
+
+                return query.getResultList();
         }
 
         @Override

--- a/src/main/java/com/USWCicrcleLink/server/club/application/service/AplictService.java
+++ b/src/main/java/com/USWCicrcleLink/server/club/application/service/AplictService.java
@@ -139,7 +139,7 @@ public class AplictService {
                 aplict.getProfile().getStudentNumber(),
                 aplict.getProfile().getMajor(),
                 aplict.getSubmittedAt(),
-                aplict.getAplictStatus(),
+                aplict.getPublicStatus(),
                 qnaList);
     }
 
@@ -158,7 +158,8 @@ public class AplictService {
                 .profile(profile)
                 .club(club)
                 .submittedAt(LocalDateTime.now())
-                .aplictStatus(AplictStatus.WAIT)
+                .publicStatus(AplictStatus.WAIT)
+                .privateStatus(AplictStatus.WAIT)
                 .build();
 
         // 답변 저장

--- a/src/main/java/com/USWCicrcleLink/server/global/data/DummyData.java
+++ b/src/main/java/com/USWCicrcleLink/server/global/data/DummyData.java
@@ -382,7 +382,8 @@ public class DummyData {
                                 .club(flagClub)
                                 .submittedAt(LocalDateTime.now())
 
-                                .aplictStatus(AplictStatus.FAIL)
+                                .privateStatus(AplictStatus.FAIL)
+                                .publicStatus(AplictStatus.WAIT)
                                 .build();
                 aplictRepository.save(aplict3);
 
@@ -391,7 +392,8 @@ public class DummyData {
                                 .club(flagClub)
                                 .submittedAt(LocalDateTime.now())
 
-                                .aplictStatus(AplictStatus.FAIL)
+                                .privateStatus(AplictStatus.FAIL)
+                                .publicStatus(AplictStatus.WAIT)
                                 .build();
                 aplictRepository.save(aplict4);
 
@@ -406,7 +408,8 @@ public class DummyData {
                                 .profile(profile1)
                                 .club(badmintonClub)
                                 .submittedAt(LocalDateTime.now())
-                                .aplictStatus(AplictStatus.PASS)
+                                .privateStatus(AplictStatus.PASS)
+                                .publicStatus(AplictStatus.WAIT)
                                 .build();
                 aplictRepository.save(badmintonAplict);
 
@@ -421,7 +424,8 @@ public class DummyData {
                                 .profile(profile1)
                                 .club(volunteerClub)
                                 .submittedAt(LocalDateTime.now())
-                                .aplictStatus(AplictStatus.FAIL)
+                                .privateStatus(AplictStatus.FAIL)
+                                .publicStatus(AplictStatus.WAIT)
                                 .build();
                 aplictRepository.save(volunteerAplict);
 
@@ -476,6 +480,95 @@ public class DummyData {
                                 .clubCategory(clubCategory2)
                                 .build();
                 clubCategoryMappingRepository.save(mapping5);
+
+                // Postman Test Users
+                User testUser1 = User.builder()
+                                .userUUID(UUID.randomUUID())
+                                .userAccount("test1")
+                                .userPw(passwordEncoder.encode("12345"))
+                                .email("test1")
+                                .userCreatedAt(LocalDateTime.now())
+                                .userUpdatedAt(LocalDateTime.now())
+                                .role(Role.USER)
+                                .build();
+                userRepository.save(testUser1);
+
+                User testUser2 = User.builder()
+                                .userUUID(UUID.randomUUID())
+                                .userAccount("test2")
+                                .userPw(passwordEncoder.encode("12345"))
+                                .email("test2")
+                                .userCreatedAt(LocalDateTime.now())
+                                .userUpdatedAt(LocalDateTime.now())
+                                .role(Role.USER)
+                                .build();
+                userRepository.save(testUser2);
+
+                User testUser3 = User.builder()
+                                .userUUID(UUID.randomUUID())
+                                .userAccount("test3")
+                                .userPw(passwordEncoder.encode("12345"))
+                                .email("test3")
+                                .userCreatedAt(LocalDateTime.now())
+                                .userUpdatedAt(LocalDateTime.now())
+                                .role(Role.USER)
+                                .build();
+                userRepository.save(testUser3);
+
+                Profile testProfile1 = Profile.builder()
+                                .user(testUser1)
+                                .userName("테스터1")
+                                .studentNumber("11111111")
+                                .userHp("01011111111")
+                                .major("테스트학과")
+                                .profileCreatedAt(LocalDateTime.now())
+                                .profileUpdatedAt(LocalDateTime.now())
+                                .memberType(MemberType.REGULARMEMBER)
+                                .build();
+                profileRepository.save(testProfile1);
+
+                Profile testProfile2 = Profile.builder()
+                                .user(testUser2)
+                                .userName("테스터2")
+                                .studentNumber("22222222")
+                                .userHp("01022222222")
+                                .major("테스트학과")
+                                .profileCreatedAt(LocalDateTime.now())
+                                .profileUpdatedAt(LocalDateTime.now())
+                                .memberType(MemberType.REGULARMEMBER)
+                                .build();
+                profileRepository.save(testProfile2);
+
+                Profile testProfile3 = Profile.builder()
+                                .user(testUser3)
+                                .userName("테스터3")
+                                .studentNumber("33333333")
+                                .userHp("01033333333")
+                                .major("테스트학과")
+                                .profileCreatedAt(LocalDateTime.now())
+                                .profileUpdatedAt(LocalDateTime.now())
+                                .memberType(MemberType.REGULARMEMBER)
+                                .build();
+                profileRepository.save(testProfile3);
+
+                // test1, test2 apply to FLAG
+                Aplict testAplict1 = Aplict.builder()
+                                .profile(testProfile1)
+                                .club(flagClub)
+                                .submittedAt(LocalDateTime.now())
+                                .privateStatus(AplictStatus.WAIT)
+                                .publicStatus(AplictStatus.WAIT)
+                                .build();
+                aplictRepository.save(testAplict1);
+
+                Aplict testAplict2 = Aplict.builder()
+                                .profile(testProfile2)
+                                .club(flagClub)
+                                .submittedAt(LocalDateTime.now())
+                                .privateStatus(AplictStatus.WAIT)
+                                .publicStatus(AplictStatus.WAIT)
+                                .build();
+                aplictRepository.save(testAplict2);
 
         }
 
@@ -564,7 +657,8 @@ public class DummyData {
                                 .profile(profile)
                                 .club(allaboutClub)
                                 .submittedAt(LocalDateTime.now())
-                                .aplictStatus(AplictStatus.PASS)
+                                .privateStatus(AplictStatus.PASS)
+                                .publicStatus(AplictStatus.WAIT)
                                 .build();
 
                 aplictRepository.save(aplict);
@@ -641,7 +735,8 @@ public class DummyData {
                                 .profile(profile)
                                 .club(gullisaeClub)
                                 .submittedAt(LocalDateTime.now())
-                                .aplictStatus(AplictStatus.PASS)
+                                .privateStatus(AplictStatus.PASS)
+                                .publicStatus(AplictStatus.WAIT)
                                 .build();
 
                 aplictRepository.save(aplict);

--- a/src/main/java/com/USWCicrcleLink/server/user/dto/MyAplictResponse.java
+++ b/src/main/java/com/USWCicrcleLink/server/user/dto/MyAplictResponse.java
@@ -24,7 +24,7 @@ public class MyAplictResponse {
 
     private String ClubRoomNumber;
 
-    private AplictStatus aplictStatus;
+    private AplictStatus publicStatus;
 
     private UUID aplictUUID;
 

--- a/src/main/java/com/USWCicrcleLink/server/user/service/MypageService.java
+++ b/src/main/java/com/USWCicrcleLink/server/user/service/MypageService.java
@@ -90,7 +90,7 @@ public class MypageService {
         return aplicts.stream()
                 .map(aplict -> {
                     Club club = getClubByAplictId(aplict.getAplictId()); // ID 기반 조회로 변경
-                    AplictStatus aplictStatus = aplict.getAplictStatus();
+                    AplictStatus aplictStatus = aplict.getPublicStatus();
                     return myAplictResponse(club, aplictStatus, aplict.getAplictUUID());
                 })
                 .collect(Collectors.toList());

--- a/src/main/resources/yaml/application-test.yml
+++ b/src/main/resources/yaml/application-test.yml
@@ -32,10 +32,10 @@ spring:
       on-profile: test
 
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${TEST_MYSQL_HOST}:${TEST_MYSQL_PORT}/${TEST_MYSQL_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${TEST_MYSQL_USER}
-    password: ${TEST_MYSQL_PASS}
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
 
   jpa:
     hibernate:


### PR DESCRIPTION
지원서 public_status, private_status 로 나누고 지원 결과 후에도 db에서 보관/ 리더 권한으로 지원 삭제 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to filter applicants by publication status
  * Added manual applicant deletion capability for club leaders

* **Improvements**
  * Enhanced applicant status tracking for better visibility control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->